### PR TITLE
Fix register address display format

### DIFF
--- a/packages/curvtools/src/curvtools/cli/memmap2/docs_generator/docs_generator.py
+++ b/packages/curvtools/src/curvtools/cli/memmap2/docs_generator/docs_generator.py
@@ -117,7 +117,7 @@ def create_markdown_slave_tables(detailed_ranges: Dict[str, List[Dict]]) -> str:
             sections.append("|---------|----------|--------|------|")
 
             for reg in sorted(regs, key=lambda x: x['start']):
-                sections.append(f"| {format_address(reg['start'])} - {format_address(reg['end'])} | {reg['name']} | {format_access(reg['access'])} | {format_size(reg['size'])} |")
+                sections.append(f"| {format_address(reg['start'])} | {reg['name']} | {format_access(reg['access'])} | {format_size(reg['size'])} |")
 
             sections.append("")  # Empty line
 

--- a/packages/curvtools/src/curvtools/cli/memmap2/docs_generator/make_tower.py
+++ b/packages/curvtools/src/curvtools/cli/memmap2/docs_generator/make_tower.py
@@ -35,7 +35,7 @@ class Range:
             return ' - '
         return (self.access or '').upper()
     def format_cacheable(self) -> str:
-        return "Yes" if self.cacheable else "-"
+        return "Yes" if self.cacheable else "No"
     def format_size(self) -> str:
         size_bytes = self.end - self.start + 1
         if size_bytes > 1024*1024:

--- a/packages/curvtools/test/curvtools/memmap2/test_vectors/expected/expected_markdown.md
+++ b/packages/curvtools/test/curvtools/memmap2/test_vectors/expected/expected_markdown.md
@@ -9,13 +9,13 @@ Auto-generated from memory_map.toml
                  +---------------------+                                   
     0600_10ff    |                     |                                   
                  |                     |                                   
-                 |    Flash Control    |    4kb        -            -      
+                 |    Flash Control    |    4kb        -           No      
                  |                     |                                   
     0600_0000    |                     |                                   
                  +---------------------+                                   
     0500_0073    |                     |                                   
                  |                     |                                   
-                 |     Peripherals     |    116b       -            -      
+                 |     Peripherals     |    116b       -           No      
                  |                     |                                   
     0500_0000    |                     |                                   
                  +---------------------+                                   
@@ -44,33 +44,33 @@ Auto-generated from memory_map.toml
 
 | Address | Register | Access | Size |
 |---------|----------|--------|------|
-| 06000000 - 06000003 | cmd_reg | W/O | 4 |
-| 06000004 - 06000007 | cmd_addr | R/W | 4 |
-| 06000008 - 0600000b | tag_hi | R/W | 4 |
-| 0600000c - 0600000f | tag_lo | R/W | 4 |
-| 06000010 - 06000013 | status | R/O | 4 |
+| 06000000 | cmd_reg | W/O | 4 |
+| 06000004 | cmd_addr | R/W | 4 |
+| 06000008 | tag_hi | R/W | 4 |
+| 0600000c | tag_lo | R/W | 4 |
+| 06000010 | status | R/O | 4 |
 
 ## Peripherals Registers
 
 | Address | Register | Access | Size |
 |---------|----------|--------|------|
-| 05000000 - 05000003 | uart.rx_status | R/O | 4 |
-| 05000004 - 05000007 | uart.tx_status | R/O | 4 |
-| 05000008 - 0500000b | uart.rx_read_addr | R/O | 4 |
-| 0500000c - 0500000f | uart.tx_write_addr | W/O | 4 |
-| 05000010 - 05000013 | spi.rx_status | R/O | 4 |
-| 05000014 - 05000017 | spi.tx_status | R/O | 4 |
-| 05000018 - 0500001b | spi.rx_read_addr | R/O | 4 |
-| 0500001c - 0500001f | spi.tx_write_addr | W/O | 4 |
-| 05000020 - 05000023 | i2c.rx_status | R/O | 4 |
-| 05000024 - 05000027 | i2c.tx_status | R/O | 4 |
-| 05000028 - 0500002b | i2c.rx_read_addr | R/O | 4 |
-| 0500002c - 0500002f | i2c.tx_write_addr | W/O | 4 |
-| 05000040 - 05000043 | gpio.dir | R/W | 4 |
-| 05000044 - 05000047 | gpio.inputs | R/O | 4 |
-| 0500004c - 0500004f | gpio.outputs | W/O | 4 |
-| 05000060 - 05000063 | leds.outputs | W/O | 4 |
-| 05000070 - 05000073 | switches.inputs | R/O | 4 |
+| 05000000 | uart.rx_status | R/O | 4 |
+| 05000004 | uart.tx_status | R/O | 4 |
+| 05000008 | uart.rx_read_addr | R/O | 4 |
+| 0500000c | uart.tx_write_addr | W/O | 4 |
+| 05000010 | spi.rx_status | R/O | 4 |
+| 05000014 | spi.tx_status | R/O | 4 |
+| 05000018 | spi.rx_read_addr | R/O | 4 |
+| 0500001c | spi.tx_write_addr | W/O | 4 |
+| 05000020 | i2c.rx_status | R/O | 4 |
+| 05000024 | i2c.tx_status | R/O | 4 |
+| 05000028 | i2c.rx_read_addr | R/O | 4 |
+| 0500002c | i2c.tx_write_addr | W/O | 4 |
+| 05000040 | gpio.dir | R/W | 4 |
+| 05000044 | gpio.inputs | R/O | 4 |
+| 0500004c | gpio.outputs | W/O | 4 |
+| 05000060 | leds.outputs | W/O | 4 |
+| 05000070 | switches.inputs | R/O | 4 |
 
 ## Flash Buffers
 


### PR DESCRIPTION
- Changed register address display in markdown tables from range format (start - end) to single address
- Updated cacheable field formatting to display "No" instead of "-" when not cacheable
- Updated test expectations to reflect the new formatting