### PR TITLE
Remove redundant Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ unsetup-editable-installs:
 	fi
 
 .PHONY: unsetup
-unsetup: unsetup-editable-installs clean-venv clean
+unsetup: unsetup-editable-installs clean
 	@$(UV) tool uninstall --all -q
 	@echo "✓ Removed CLI tools from uv tool environment"
 


### PR DESCRIPTION
- Remove `clean-venv` from `unsetup` target dependencies since it was already merged into `clean`